### PR TITLE
replace 'gwt-events' with 'gwt-event'

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
-GWT Events
-==========
+GWT Event
+=========
 
 A future-proof port of the `com.google.web.bindery.event.Event` GWT module,
 with no dependency on `gwt-user` (besides the Java Runtime Emulation),

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -89,11 +89,11 @@ dependencies {
 task transpile(type: JavaExec) {
   inputs.files configurations.j2cl
   inputs.files sourceSets.main.allJava
-  outputs.file "${buildDir}/libs/gwt-events.js.zip"
+  outputs.file "${buildDir}/libs/gwt-event.js.zip"
 
   main = 'com.google.j2cl.transpiler.J2clTranspiler'
   classpath = configurations.j2cl_transpiler
-  args = [ "-cp", configurations.j2cl.asPath, "-d", "${buildDir}/libs/gwt-events.js.zip" ] \
+  args = [ "-cp", configurations.j2cl.asPath, "-d", "${buildDir}/libs/gwt-event.js.zip" ] \
        + sourceSets.main.allJava
 }
 assemble.dependsOn transpile

--- a/buildSrc/src/main/kotlin/local/maven-publish.gradle.kts
+++ b/buildSrc/src/main/kotlin/local/maven-publish.gradle.kts
@@ -44,7 +44,7 @@ val mavenPublication = publishing.publications.create<MavenPublication>("maven")
     pom {
         name.set(provider { "$groupId:$artifactId" })
         description.set(provider { project.description ?: name.get() })
-        url.set("https://github.com/gwtproject/gwt-events")
+        url.set("https://github.com/gwtproject/gwt-event")
         developers {
             developer {
                 name.set("The GWT Project Authors")
@@ -52,9 +52,9 @@ val mavenPublication = publishing.publications.create<MavenPublication>("maven")
             }
         }
         scm {
-            connection.set("https://github.com/gwtproject/gwt-events.git")
-            developerConnection.set("scm:git:ssh://github.com:gwtproject/gwt-events.git")
-            url.set("https://github.com/gwtproject/gwt-events")
+            connection.set("https://github.com/gwtproject/gwt-event.git")
+            developerConnection.set("scm:git:ssh://github.com:gwtproject/gwt-event.git")
+            url.set("https://github.com/gwtproject/gwt-event")
         }
         licenses {
             license {


### PR DESCRIPTION
Found a few places where the old name was used. 